### PR TITLE
Fix: Resolve 'Cannot use import statement outside a module' error

### DIFF
--- a/api/protected-app.js
+++ b/api/protected-app.js
@@ -25,15 +25,57 @@ export default async function handler(req, res) {
     }
     // Sanitize input
     const safeName = String(name).replace(/[^a-zA-Z0-9_-]/g, '');
-    const safeFile = String(file).replace(/[^a-zA-Z0-9_.-]/g, '');
-    const appPath = path.join(process.cwd(), 'apps', safeName, safeFile);
+    let safeFile = String(file).replace(/[^a-zA-Z0-9_.-]/g, '');
+
+    // If a .jsx file is requested, change it to .js as Vite compiles JSX to JS
+    if (safeFile.endsWith('.jsx')) {
+      safeFile = safeFile.replace('.jsx', '.js');
+    }
+
+    // Construct path to the built assets in the 'dist' directory
+    // Apps are expected to be in dist/apps/[AppName]/[FileName]
+    // CSS files are in dist/assets/[AppName]-[hash].css - this will need adjustment
+    // For now, direct JS/CSS requests will assume simple naming.
+    let appPath;
+    if (safeFile.endsWith('.css')) {
+      // This is a simplified assumption. Vite produces hashed CSS file names in dist/assets.
+      // A more robust solution would involve a manifest file from Vite to map original names to hashed names.
+      // For now, let's try to find a file that starts with App and ends with .css in the app's asset folder.
+      // This is NOT a robust solution.
+      // Example: dist/assets/App-D6bR3a_T.css for Calculator
+      // We need to list files or use a manifest. For now, we'll assume a simplified name or defer proper CSS handling.
+      // Let's assume the client will request the exact hashed filename for CSS if needed,
+      // or the JS bundle will load it.
+      // The current 'file' parameter might be 'App.css'. The actual file is e.g. 'App-D6bR3a_T.css'.
+      // This part is tricky without a manifest file or a more predictable naming scheme for app-specific CSS.
+      // For this step, we will primarily focus on JS.
+      // A simplified approach for CSS: assume it's named App.css in the app's dist folder (if Vite puts it there)
+      // Looking at the build output:
+      // dist/assets/App-D6bR3a_T.css
+      // dist/assets/App-DvAMSrX6.css
+      // dist/assets/App-BiOncaBC.css
+      // These are not directly in dist/apps/[AppName]/
+      // This endpoint might not be the right way to serve these hashed CSS assets.
+      // The HTML that loads the JS should ideally also load the correct hashed CSS.
+      // Let's assume for now `file` will be the *exact* filename like `App-D6bR3a_T.css` and `name` would be `assets`.
+      if (safeName === 'assets') { // A convention: if 'name' is 'assets', 'file' is the direct filename in dist/assets
+        appPath = path.join(process.cwd(), 'dist', 'assets', safeFile);
+      } else {
+        // If specific app CSS is requested like 'apps/Notes/App.css', it's not directly available.
+        // The JS bundle (e.g. dist/apps/Notes/App.js) will import its CSS.
+        // For now, if a .css file is requested for an app, we'll return 404 as it's not directly there.
+        res.status(404).json({ error: `CSS files are bundled. Request specific asset from /assets/ or ensure JS handles CSS import.` });
+        return;
+      }
+    } else {
+      appPath = path.join(process.cwd(), 'dist', 'apps', safeName, safeFile);
+    }
+
     try {
       const content = await fs.readFile(appPath);
       // Set content type based on file extension
       if (safeFile.endsWith('.js')) {
         res.setHeader('Content-Type', 'application/javascript');
-      } else if (safeFile.endsWith('.jsx')) {
-        res.setHeader('Content-Type', 'application/javascript'); // JSX is still JS for browser
       } else if (safeFile.endsWith('.css')) {
         res.setHeader('Content-Type', 'text/css');
       } else if (safeFile.endsWith('.json')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "bcrypt": "^6.0.0",
         "jsonwebtoken": "^9.0.2",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-rnd": "^10.4.11"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -1590,6 +1591,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2148,7 +2158,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2355,6 +2364,18 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2436,6 +2457,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2579,6 +2609,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2587,6 +2628,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/re-resizable": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
+      "integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {
@@ -2610,6 +2661,26 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
+      "integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2618,6 +2689,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-rnd": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.5.2.tgz",
+      "integrity": "sha512-0Tm4x7k7pfHf2snewJA8x7Nwgt3LV+58MVEWOVsFjk51eYruFEa6Wy7BNdxt4/lH0wIRsu7Gm3KjSXY2w7YaNw==",
+      "license": "MIT",
+      "dependencies": {
+        "re-resizable": "6.11.2",
+        "react-draggable": "4.4.6",
+        "tslib": "2.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2781,6 +2867,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "bcrypt": "^6.0.0",
     "jsonwebtoken": "^9.0.2",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-rnd": "^10.4.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,38 @@
 // filepath: c:\Users\Costi\Documents\zeroOS\vite.config.js
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+import { readdirSync } from 'fs';
 
 // https://vite.dev/config/
+
+// Dynamically create input entries for each app in the apps directory
+const appsDir = resolve(__dirname, 'apps');
+const appEntries = readdirSync(appsDir, { withFileTypes: true })
+  .filter(dirent => dirent.isDirectory())
+  .reduce((acc, dirent) => {
+    acc[`apps/${dirent.name}/App`] = resolve(appsDir, dirent.name, 'App.jsx');
+    return acc;
+  }, {});
+
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      input: {
+        // Main app entry (if you have one, e.g., src/main.jsx)
+        main: resolve(__dirname, 'index.html'),
+        // Spread the app entries
+        ...appEntries,
+      },
+      output: {
+        // Ensures that entry files are named consistently (e.g., App.js)
+        // And placed in a directory structure reflecting the input key
+        entryFileNames: `[name].js`,
+        chunkFileNames: `assets/[name]-[hash].js`,
+        assetFileNames: `assets/[name]-[hash].[ext]`
+      }
+    },
+    outDir: 'dist', // Default is 'dist', explicitly stating for clarity
+  }
 });


### PR DESCRIPTION
- Configure Vite to build individual apps in the 'apps/' directory as separate entry points.
- Update 'api/protected-app.js' to serve transpiled JavaScript files from the 'dist/apps/' build output directory.
- Add missing 'react-rnd' dependency.

This ensures that JSX files are correctly transpiled to JavaScript and served with the appropriate module context, resolving the client-side loading error.