### PR TITLE
Refactor AppLoader to use dynamic import for app modules

### DIFF
--- a/src/AppLoader.jsx
+++ b/src/AppLoader.jsx
@@ -7,21 +7,11 @@ export default function AppLoader({ onAppClick, apps }) {
   const handleAppClick = async (app) => {
     const scriptUrl = app.script;
     try {
-      const res = await fetch(scriptUrl, { credentials: 'include' });
-      if (!res.ok) throw new Error('Failed to fetch app script');
-      const code = await res.text();
+      // Dynamically import the module
+      const module = await import(/* @vite-ignore */ scriptUrl);
+      const Component = module.default || module[Object.keys(module)[0]]; // Try default, then first named export
 
-      // Remove any import/export statements from the code
-      const sanitized = code
-        .replace(/import\s+.*from\s+.*;?/g, '')
-        .replace(/export\s+default\s+/g, 'return ')
-        .replace(/export\s+\{[^}]*\};?/g, '');
-
-      // Wrap in a function to provide React in scope
-      // eslint-disable-next-line no-new-func
-      const Component = new Function('React', `${sanitized}`)(React);
-
-      if (!Component) throw new Error('No default export found in app');
+      if (!Component) throw new Error('No component found in app module');
       onAppClick({ ...app, Component });
     } catch (e) {
       alert('Failed to load app: ' + app.name + '\n' + e.message);


### PR DESCRIPTION
- Replaced fetch and new Function() with dynamic import() to correctly load ES modules for apps.
- Updated component retrieval to check for module.default or the first named export to handle different export styles and resolve 'No default export found' errors.