### PR TITLE
fix(apps): Bundle React into Notes app to resolve useState error

### DIFF
--- a/vite.lib.config.js
+++ b/vite.lib.config.js
@@ -27,15 +27,15 @@ export default defineConfig(({ mode }) => {
       },
       rollupOptions: {
         // Externalize deps that shouldn't be bundled into the library
-        external: ['react', 'react-dom', 'react/jsx-runtime'],
+        // external: ['react', 'react-dom', 'react/jsx-runtime'], // Temporarily removed for testing
         output: {
           // Provide global variables to use in the UMD build
           // for externalized deps
-          globals: {
-            'react': 'React',
-            'react-dom': 'ReactDOM',
-            'react/jsx-runtime': 'jsxRuntime' // Or however it's typically named
-          },
+          // globals: {
+          //   'react': 'React',
+          //   'react-dom': 'ReactDOM',
+          //   'react/jsx-runtime': 'jsxRuntime' // Or however it's typically named
+          // },
           assetFileNames: 'style.css',
         },
       },


### PR DESCRIPTION
- Modified vite.lib.config.js to remove React from externals, forcing it to be bundled with the Notes app.
- This is a workaround for an issue where `useState` was not found when React was externalized, possibly due to React 19 changes or build configuration interactions.
- Added `cross-env` as a dev dependency as it was missing and required for app build scripts.