### PR TITLE
Fix: Resolve React loading issue for micro-apps

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
     <script type="importmap">
     {
       "imports": {
-        "react": "./assets/vendor-react.js",
-        "react-dom": "./assets/vendor-react.js",
-        "react-dom/client": "./assets/vendor-react.js",
-        "react/jsx-runtime": "./assets/vendor-react.js"
+        "react": "/assets/vendor-react.js",
+        "react-dom": "/assets/vendor-react.js",
+        "react-dom/client": "/assets/vendor-react.js",
+        "react/jsx-runtime": "/assets/vendor-react.js"
       }
     }
     </script>

--- a/vite.lib.config.js
+++ b/vite.lib.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
       },
       rollupOptions: {
         // Externalize deps that shouldn't be bundled into the library
-        // external: ['react', 'react-dom', 'react/jsx-runtime'], // Temporarily removed for testing
+        external: ['react', 'react-dom', 'react/jsx-runtime'],
         output: {
           // Provide global variables to use in the UMD build
           // for externalized deps


### PR DESCRIPTION
- Ensure React, ReactDOM, and jsx-runtime are externalized in the build configuration for individual apps (vite.lib.config.js). This allows them to use the shell's React instance.
- Update the import map in index.html to use absolute paths (e.g., /assets/vendor-react.js) for React modules. This makes the resolution more robust in production environments like Vercel.

These changes address the error "The requested module 'react' does not provide an export named 'useState'" when loading micro-apps like Notes. The issue stemmed from the micro-app not correctly resolving its React imports to the shell's provided React bundle.