### PR TITLE
Fix app data loading and align with security flow

### DIFF
--- a/api/login.js
+++ b/api/login.js
@@ -23,8 +23,9 @@ export default async function handler(req, res) {
   if (user) {
     const match = await bcrypt.compare(password, user.hashedPassword);
     if (match) {
-      const token = jwt.sign({ username }, JWT_SECRET, { expiresIn: '1d' }); // Store username in token
-      res.setHeader('Set-Cookie', `token=${token}; HttpOnly; Path=/; SameSite=Lax; Max-Age=86400`);
+      const token = jwt.sign({ username }, JWT_SECRET, { expiresIn: '2h' }); // Token valid for 2 hours
+      // Make it a session cookie by not setting Max-Age or Expires
+      res.setHeader('Set-Cookie', `token=${token}; HttpOnly; Path=/; SameSite=Lax`);
       res.status(200).json({ ok: true, username }); // Send username back
     } else {
       res.status(401).json({ error: 'Invalid username or password' });


### PR DESCRIPTION
- Resolved 'Failed to load application data' error by correctly parsing API response in App.jsx.
- Implemented initial fetch of encrypted app data before login.
- Server now caches app encryption keys for 2 minutes.
- Login API now sets a session cookie for JWT, aligning with session erasure requirements.
- Refactored App.jsx to use pre-loaded app data for key retrieval upon login.
- Ensured api/apps.js exports getDecryptionKeys and api/decryption-keys.js uses it.