### PR TITLE
Fix: Error modal layering and app opening freeze

### DIFF
--- a/src/Desktop.jsx
+++ b/src/Desktop.jsx
@@ -6,21 +6,23 @@ const Desktop = () => {
   const [windows, setWindows] = useState([]);
   const [zIndexCounter, setZIndexCounter] = useState(1);
 
-  const openApp = (appName, Component) => {
-    const id = `${appName}_${Date.now()}`;
+  const openApp = (appWithHtml) => {
+    const id = `${appWithHtml.name}_${Date.now()}`;
     setWindows(prev => [
       ...prev,
       {
         id,
-        name: appName,
-        x: 100,
-        y: 100,
-        width: 400,
-        height: 300,
+        name: appWithHtml.name,
+        x: appWithHtml.defaultX || 100,
+        y: appWithHtml.defaultY || 100,
+        width: appWithHtml.defaultWidth || 400,
+        height: appWithHtml.defaultHeight || 300,
+        minWidth: appWithHtml.minWidth || 200,
+        minHeight: appWithHtml.minHeight || 150,
         zIndex: zIndexCounter,
         isMinimized: false,
         isMaximized: false,
-        Component,
+        htmlContent: appWithHtml.htmlContent, // Store HTML content
       },
     ]);
     setZIndexCounter(prev => prev + 1);

--- a/src/ErrorDisplayModal.css
+++ b/src/ErrorDisplayModal.css
@@ -9,7 +9,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000; /* Ensure it's above other content */
+  z-index: 2147483647; /* Ensure it's above ALL other content */
 }
 
 .error-modal-content {

--- a/src/WindowManager.jsx
+++ b/src/WindowManager.jsx
@@ -19,9 +19,9 @@ export default function WindowManager({
           onMaximize={() => onMaximize(w.id)}
           onDragStop={(x,y) => onDragStop(w.id,x,y)}
           onResizeStop={(width,height,x,y) => onResizeStop(w.id,width,height,x,y)}
-        >
-          <w.Component />
-        </Window>
+          title={w.name} // Pass app name as title for the window and iframe
+          // htmlContent is passed via {...w} which is handled by Window.jsx to render in iframe
+        />
       ))}
     </>
   );


### PR DESCRIPTION
- Increased z-index of ErrorDisplayModal to ensure it appears above all other elements.
- Refactored app opening logic:
  - Desktop.jsx now correctly processes app objects containing HTML content and dimensions.
  - WindowManager.jsx passes app HTML content and title to Window.jsx.
  - Window.jsx's existing iframe rendering capability is now properly utilized, preventing crashes when opening apps.
- Ensured app dimensions (width, height, minWidth, minHeight) from app configuration are respected.